### PR TITLE
Cluster port incr config

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -1449,6 +1449,12 @@ lua-time-limit 5000
 #
 # cluster-node-timeout 15000
 
+# Cluster port incr is the offset from command port to cluster bus port. 
+# Cluster port = command port + cluster port incr.
+# User could define the differnce from them. 
+#
+# cluster-port-incr 10000
+
 # A replica of a failing master will avoid to start a failover if its data
 # looks too old.
 #

--- a/redis.conf
+++ b/redis.conf
@@ -1451,7 +1451,7 @@ lua-time-limit 5000
 
 # Cluster port incr is the offset from command port to cluster bus port. 
 # Cluster port = command port + cluster port incr.
-# User could define the differnce from them. 
+# User could define the difference from them. 
 #
 # cluster-port-incr 10000
 

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -212,9 +212,9 @@ int clusterLoadConfig(char *filename) {
         }
         n->port = atoi(port);
         /* In older versions of nodes.conf the "@busport" part is missing.
-         * In this case we set it to the default offset of 10000 from the
+         * In this case we set it to the default offset of server.cluster_port_incr from the
          * base port. */
-        n->cport = busp ? atoi(busp) : n->port + CLUSTER_PORT_INCR;
+        n->cport = busp ? atoi(busp) : n->port + server.cluster_port_incr;
 
         /* The plaintext port for client in a TLS cluster (n->pport) is not
          * stored in nodes.conf. It is received later over the bus protocol. */
@@ -473,7 +473,7 @@ void deriveAnnouncedPorts(int *announced_port, int *announced_pport,
     /* Default announced ports. */
     *announced_port = port;
     *announced_pport = server.tls_cluster ? server.port : 0;
-    *announced_cport = port + CLUSTER_PORT_INCR;
+    *announced_cport = port + server.cluster_port_incr;
     /* Config overriding announced ports. */
     if (server.tls_cluster && server.cluster_announce_tls_port) {
         *announced_port = server.cluster_announce_tls_port;
@@ -550,24 +550,27 @@ void clusterInit(void) {
     /* We need a listening TCP port for our cluster messaging needs. */
     server.cfd.count = 0;
 
+   
+
     /* Port sanity check II
      * The other handshake port check is triggered too late to stop
      * us from trying to use a too-high cluster port number. */
     int port = server.tls_cluster ? server.tls_port : server.port;
-    if (port > (65535-CLUSTER_PORT_INCR)) {
+    if (port > (65535-server.cluster_port_incr)) {
         serverLog(LL_WARNING, "Redis port number too high. "
-                   "Cluster communication port is 10,000 port "
+                   "Cluster communication port is %d port "
                    "numbers higher than your Redis port. "
-                   "Your Redis port number must be 55535 or less.");
+                   "Your Redis port number must be %d or less.", server.cluster_port_incr, 65535-server.cluster_port_incr);
         exit(1);
     }
     if (!server.bindaddr_count) {
         serverLog(LL_WARNING, "No bind address is configured, but it is required for the Cluster bus.");
         exit(1);
     }
-    if (listenToPort(port+CLUSTER_PORT_INCR, &server.cfd) == C_ERR) {
+    if (listenToPort(port+server.cluster_port_incr, &server.cfd) == C_ERR) {
         exit(1);
     }
+    
     if (createSocketAcceptHandler(&server.cfd, clusterAcceptHandler) != C_OK) {
         serverPanic("Unrecoverable error creating Redis Cluster socket accept handler.");
     }
@@ -4542,7 +4545,7 @@ NULL
                 return;
             }
         } else {
-            cport = port + CLUSTER_PORT_INCR;
+            cport = port + server.cluster_port_incr;
         }
 
         if (clusterStartHandshake(c->argv[2]->ptr,port,cport) == 0 &&

--- a/src/cluster.h
+++ b/src/cluster.h
@@ -9,7 +9,6 @@
 #define CLUSTER_OK 0          /* Everything looks ok */
 #define CLUSTER_FAIL 1        /* The cluster can't work */
 #define CLUSTER_NAMELEN 40    /* sha1 hex length */
-#define CLUSTER_PORT_INCR 10000 /* Cluster port = baseport + PORT_INCR */
 
 /* The following defines are amount of time, sometimes expressed as
  * multiplicators of the node timeout value (when ending with MULT). */

--- a/src/config.c
+++ b/src/config.c
@@ -2602,6 +2602,7 @@ standardConfig configs[] = {
     createIntConfig("timeout", NULL, MODIFIABLE_CONFIG, 0, INT_MAX, server.maxidletime, 0, INTEGER_CONFIG, NULL, NULL), /* Default client timeout: infinite */
     createIntConfig("replica-announce-port", "slave-announce-port", MODIFIABLE_CONFIG, 0, 65535, server.slave_announce_port, 0, INTEGER_CONFIG, NULL, NULL),
     createIntConfig("tcp-backlog", NULL, IMMUTABLE_CONFIG, 0, INT_MAX, server.tcp_backlog, 511, INTEGER_CONFIG, NULL, NULL), /* TCP listen backlog. */
+    createIntConfig("cluster-port-incr", NULL, IMMUTABLE_CONFIG, 1, 10000, server.cluster_port_incr, 10000, INTEGER_CONFIG, NULL, NULL),    
     createIntConfig("cluster-announce-bus-port", NULL, MODIFIABLE_CONFIG, 0, 65535, server.cluster_announce_bus_port, 0, INTEGER_CONFIG, NULL, NULL), /* Default: Use +10000 offset. */
     createIntConfig("cluster-announce-port", NULL, MODIFIABLE_CONFIG, 0, 65535, server.cluster_announce_port, 0, INTEGER_CONFIG, NULL, NULL), /* Use server.port */
     createIntConfig("cluster-announce-tls-port", NULL, MODIFIABLE_CONFIG, 0, 65535, server.cluster_announce_tls_port, 0, INTEGER_CONFIG, NULL, NULL), /* Use server.tls_port */

--- a/src/server.h
+++ b/src/server.h
@@ -1596,6 +1596,7 @@ struct redisServer {
                                    xor of NOTIFY_... flags. */
     /* Cluster */
     int cluster_enabled;      /* Is cluster enabled? */
+    int cluster_port_incr;    /* Cluster port = baseport + cluster_port_incr */
     mstime_t cluster_node_timeout; /* Cluster node timeout. */
     char *cluster_configfile; /* Cluster auto-generated config file name. */
     struct clusterState *cluster;  /* State of the cluster */

--- a/tests/cluster/run.tcl
+++ b/tests/cluster/run.tcl
@@ -15,6 +15,7 @@ proc main {} {
     spawn_instance redis $::redis_base_port $::instances_count {
         "cluster-enabled yes"
         "appendonly yes"
+        "cluster-port-incr 100"
     }
     run_tests
     cleanup

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -156,6 +156,7 @@ start_server {tags {"introspection"}} {
             aof_rewrite_cpulist
             bgsave_cpulist
             set-proc-title
+            cluster-port-incr
         }
 
         if {!$::tls} {


### PR DESCRIPTION
Before this PR, for a cluster node, cluster bus port = command port+ 10000, which is a fixed value.
Now we could allow user to config the offset between cluster bus and command port, it is more flexible and friendly. 

The parameter "cluster-port-incr" can be added in redis.conf, the value could be from 1 to 10000. 
The default value is 10000.