### PR TITLE
Fix the issue of master reboot in very short time

### DIFF
--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -76,7 +76,7 @@ typedef struct sentinelAddr {
 #define SRI_RECONF_DONE (1<<10)     /* Slave synchronized with new master. */
 #define SRI_FORCE_FAILOVER (1<<11)  /* Force failover with master up. */
 #define SRI_SCRIPT_KILL_SENT (1<<12) /* SCRIPT KILL already sent on -BUSY */
-#define SRI_MASTER_REBOOT  (1<<13)
+#define SRI_MASTER_REBOOT  (1<<13)   /* this flag set thinks that master is rebooted in very shot time*/
 
 /* Note: times are in milliseconds. */
 #define SENTINEL_PING_PERIOD 1000

--- a/src/sentinel.c
+++ b/src/sentinel.c
@@ -76,6 +76,7 @@ typedef struct sentinelAddr {
 #define SRI_RECONF_DONE (1<<10)     /* Slave synchronized with new master. */
 #define SRI_FORCE_FAILOVER (1<<11)  /* Force failover with master up. */
 #define SRI_SCRIPT_KILL_SENT (1<<12) /* SCRIPT KILL already sent on -BUSY */
+#define SRI_MASTER_REBOOT  (1<<13)
 
 /* Note: times are in milliseconds. */
 #define SENTINEL_PING_PERIOD 1000
@@ -193,6 +194,8 @@ typedef struct sentinelRedisInstance {
     mstime_t s_down_since_time; /* Subjectively down since time. */
     mstime_t o_down_since_time; /* Objectively down since time. */
     mstime_t down_after_period; /* Consider it down after that period. */
+    mstime_t master_reboot_down_after_period; /* Consider master down after that period. */
+    mstime_t master_reboot_since_time; /* master reboot time since time. */
     mstime_t info_refresh;  /* Time at which we received INFO output from it. */
     dict *renamed_commands;     /* Commands renamed in this instance:
                                    Sentinel will use the alternative commands
@@ -564,6 +567,21 @@ void sentinelCheckConfigFile(void) {
     }
 }
 
+void sentinelInitialMasterRebootDownAfterPeriod(void) {
+    dictIterator *di;
+    dictEntry *de;
+
+    di = dictGetIterator(sentinel.masters);
+    while((de = dictNext(di)) != NULL) {
+        sentinelRedisInstance *ri = dictGetVal(de);
+        if(ri->down_after_period > SENTINEL_PING_PERIOD)
+            ri->master_reboot_down_after_period = SENTINEL_PING_PERIOD * 10;
+        else
+            ri->master_reboot_down_after_period = ri->down_after_period * 10;
+    }
+    dictReleaseIterator(di);
+}
+
 /* This function gets called when the server is in Sentinel mode, started,
  * loaded the configuration, and is ready for normal operations. */
 void sentinelIsRunning(void) {
@@ -583,6 +601,8 @@ void sentinelIsRunning(void) {
 
     /* Log its ID to make debugging of issues simpler. */
     serverLog(LL_WARNING,"Sentinel ID is %s", sentinel.myid);
+
+    sentinelInitialMasterRebootDownAfterPeriod();
 
     /* We want to generate a +monitor event for every configured master
      * at startup. */
@@ -1340,6 +1360,9 @@ sentinelRedisInstance *createSentinelRedisInstance(char *name, int flags, char *
     ri->o_down_since_time = 0;
     ri->down_after_period = master ? master->down_after_period :
                             sentinel_default_down_after;
+    if(ri->flags & SRI_SLAVE){
+        ri->master_reboot_down_after_period = master ? master->master_reboot_down_after_period :SENTINEL_PING_PERIOD*10;
+    }                        
     ri->master_link_down_time = 0;
     ri->auth_pass = NULL;
     ri->auth_user = NULL;
@@ -2524,6 +2547,12 @@ void sentinelRefreshInstanceInfo(sentinelRedisInstance *ri, const char *info) {
             } else {
                 if (strncmp(ri->runid,l+7,40) != 0) {
                     sentinelEvent(LL_NOTICE,"+reboot",ri,"%@");
+
+                    if(ri->flags & SRI_MASTER) {
+                        ri->flags |= SRI_MASTER_REBOOT;
+                        ri->master_reboot_since_time = mstime();
+                    }
+
                     sdsfree(ri->runid);
                     ri->runid = sdsnewlen(l+7,40);
                 }
@@ -2791,6 +2820,10 @@ void sentinelPingReplyCallback(redisAsyncContext *c, void *reply, void *privdata
         {
             link->last_avail_time = mstime();
             link->act_ping_time = 0; /* Flag the pong as received. */
+            
+            if (ri->flags & SRI_MASTER_REBOOT && strncmp(r->str,"PONG",4) == 0)
+                ri->flags &= ~SRI_MASTER_REBOOT;
+
         } else {
             /* Send a SCRIPT KILL command if the instance appears to be
              * down because of a busy script. */
@@ -4424,7 +4457,9 @@ void sentinelCheckSubjectivelyDown(sentinelRedisInstance *ri) {
         (ri->flags & SRI_MASTER &&
          ri->role_reported == SRI_SLAVE &&
          mstime() - ri->role_reported_time >
-          (ri->down_after_period+sentinel_info_period*2)))
+          (ri->down_after_period+sentinel_info_period*2)) ||
+          (ri->flags & SRI_MASTER_REBOOT && 
+           mstime()-ri->master_reboot_since_time > ri->master_reboot_down_after_period))
     {
         /* Is subjectively down */
         if ((ri->flags & SRI_S_DOWN) == 0) {


### PR DESCRIPTION
Background Information:

Sentinel send PING request to master, replicas and other sentinels according to the "down-after-milliseconds" parameters in 
sentinel.conf or its own config file.

**If down-after-milliseconds is greater than 1000, Sentinel will send PING every second.
If down-after-milliseconds is less than 1000,  Sentinel will send PING according to the down-after-milliseconds value**

For example:

// Sentinel send PING request every 1 second
Sentinel down-after-milliseconds mymaster 60000

// Sentinel send PING request every 600 milliseconds
Sentinel down-after-milliseconds mymaster 600

Solution:


If master reboot in very short time,  Sentinel will receive one "reboot" information.
At this time, add SRI_MASTER_REBOOT to this Sentinel instance and record the master reboot time in master_reboot_since_time variable.

If Sentinel receives "Loading" reply with SRI_MASTER_REBOOT flag from master for 10 * PING time,
Sentinel think master is subjectively down, and ready to vote and failover process.

This solution could grantee if master is reboot in very short time, failover could finish in 10 seconds. 


