### PR TITLE
add new command for cluster add and remove slots in a range

### DIFF
--- a/redis.conf
+++ b/redis.conf
@@ -1881,13 +1881,13 @@ hz 10
 dynamic-hz yes
 
 # When a child rewrites the AOF file, if the following option is enabled
-# the file will be fsync-ed every 32 MB of data generated. This is useful
+# the file will be fsync-ed every 4 MB of data generated. This is useful
 # in order to commit the file to the disk more incrementally and avoid
 # big latency spikes.
 aof-rewrite-incremental-fsync yes
 
 # When redis saves RDB file, if the following option is enabled
-# the file will be fsync-ed every 32 MB of data generated. This is useful
+# the file will be fsync-ed every 4 MB of data generated. This is useful
 # in order to commit the file to the disk more incrementally and avoid
 # big latency spikes.
 rdb-save-incremental-fsync yes

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -4480,6 +4480,8 @@ void clusterCommand(client *c) {
         const char *help[] = {
 "ADDSLOTS <slot> [<slot> ...]",
 "    Assign slots to current node.",
+"ADDSLOTSRANGE <start slot> <end slot> [<start slot> <end slot> ...]",
+"    Assign slots which are between start slot and end slot to current node.",
 "BUMPEPOCH",
 "    Advance the cluster config epoch.",
 "COUNT-FAILURE-REPORTS <node-id>",
@@ -4488,6 +4490,8 @@ void clusterCommand(client *c) {
 "    Return the number of keys in <slot>.",
 "DELSLOTS <slot> [<slot> ...]",
 "    Delete slots information from current node.",
+"DELSLOTSRANGE <start slot> <end slot> [<start slot> <end slot> ...]",
+"    Delete slots information which are between start slot and end slot from current node.",
 "FAILOVER [FORCE|TAKEOVER]",
 "    Promote current replica node to being a master.",
 "FORGET <node-id>",
@@ -4615,6 +4619,77 @@ NULL
                 int retval;
 
                 /* If this slot was set as importing we can clear this
+                 * state as now we are the real owner of the slot. */
+                if (server.cluster->importing_slots_from[j])
+                    server.cluster->importing_slots_from[j] = NULL;
+
+                retval = del ? clusterDelSlot(j) :
+                               clusterAddSlot(myself,j);
+                serverAssertWithInfo(c,NULL,retval == C_OK);
+            }
+        }
+        zfree(slots);
+        clusterDoBeforeSleep(CLUSTER_TODO_UPDATE_STATE|CLUSTER_TODO_SAVE_CONFIG);
+        addReply(c,shared.ok);
+    } else if ((!strcasecmp(c->argv[1]->ptr,"addslotsrange") ||
+               !strcasecmp(c->argv[1]->ptr,"delslotsrange")) && c->argc >= 4)
+    {
+        if(c->argc % 2 == 1){
+            addReplyErrorFormat(c,"Missed one endslot");
+            return;
+        }
+
+
+        /* CLUSTER ADDSLOTSRANGE <start slot> <end slot> [start slot end slot] ... */
+        /* CLUSTER DELSLOTSRANGE <start slot> <end slot> [start slot end slot] ... */
+        int j, slot, startslot, endslot;
+        unsigned char *slots = zmalloc(CLUSTER_SLOTS);
+        int del = !strcasecmp(c->argv[1]->ptr,"delslotsrange");
+
+        memset(slots,0,CLUSTER_SLOTS);
+        
+        /* Check that all the arguments are parseable and that all the
+         * slots are not already busy. */
+        for (j = 2; j < c->argc; j += 2){
+            if ((startslot = getSlotOrReply(c,c->argv[j])) == -1) {
+                zfree(slots);
+                return;
+            }
+
+            if ((endslot = getSlotOrReply(c,c->argv[j+1])) == -1) {
+                zfree(slots);
+                return;
+            }
+
+            if(startslot > endslot){
+                addReplyErrorFormat(c,"start slot number %d is greater than end slot number %d", startslot, endslot);
+                zfree(slots);
+                return;
+            }
+
+            for(slot = startslot; slot <= endslot; slot++){
+                if (del && server.cluster->slots[slot] == NULL) {
+                    addReplyErrorFormat(c,"Slot %d is already unassigned", slot);
+                    zfree(slots);
+                    return;
+                } else if (!del && server.cluster->slots[slot]) {
+                    addReplyErrorFormat(c,"Slot %d is already busy", slot);
+                    zfree(slots);
+                    return;
+                }
+                if (slots[slot]++ == 1) {
+                    addReplyErrorFormat(c,"Slot %d specified multiple times",
+                        (int)slot);
+                    zfree(slots);
+                    return;
+                }
+            }
+        }
+        for (j = 0; j < CLUSTER_SLOTS; j++) {
+            if (slots[j]) {
+                int retval;
+                
+                 /* If this slot was set as importing we can clear this
                  * state as now we are the real owner of the slot. */
                 if (server.cluster->importing_slots_from[j])
                     server.cluster->importing_slots_from[j] = NULL;

--- a/src/config.c
+++ b/src/config.c
@@ -384,6 +384,62 @@ static int updateOOMScoreAdjValues(sds *args, const char **err, int apply) {
     return C_OK;
 }
 
+/* Parse an array of `arg_len` sds strings, validate and populate
+ * server.client_obuf_limits if valid.
+ * Used in CONFIG SET and configuration file parsing. */
+static int updateClientOutputBufferLimit(sds *args, int arg_len, const char **err) {
+    int j;
+    int class;
+    unsigned long long hard, soft;
+    int hard_err, soft_err;
+    int soft_seconds;
+    char *soft_seconds_eptr;
+    clientBufferLimitsConfig values[CLIENT_TYPE_OBUF_COUNT];
+    int classes[CLIENT_TYPE_OBUF_COUNT] = {0};
+
+    /* We need a multiple of 4: <class> <hard> <soft> <soft_seconds> */
+    if (arg_len % 4) {
+        if (err) *err = "Wrong number of arguments in "
+                        "buffer limit configuration.";
+        return C_ERR;
+    }
+
+    /* Sanity check of single arguments, so that we either refuse the
+     * whole configuration string or accept it all, even if a single
+     * error in a single client class is present. */
+    for (j = 0; j < arg_len; j += 4) {
+        class = getClientTypeByName(args[j]);
+        if (class == -1 || class == CLIENT_TYPE_MASTER) {
+            if (err) *err = "Invalid client class specified in "
+                            "buffer limit configuration.";
+            return C_ERR;
+        }
+
+        hard = memtoull(args[j+1], &hard_err);
+        soft = memtoull(args[j+2], &soft_err);
+        soft_seconds = strtoll(args[j+3], &soft_seconds_eptr, 10);
+        if (hard_err || soft_err ||
+            soft_seconds < 0 || *soft_seconds_eptr != '\0')
+        {
+            if (err) *err = "Error in hard, soft or soft_seconds setting in "
+                            "buffer limit configuration.";
+            return C_ERR;
+        }
+
+        values[class].hard_limit_bytes = hard;
+        values[class].soft_limit_bytes = soft;
+        values[class].soft_limit_seconds = soft_seconds;
+        classes[class] = 1;
+    }
+
+    /* Finally set the new config. */
+    for (j = 0; j < CLIENT_TYPE_OBUF_COUNT; j++) {
+        if (classes[j]) server.client_obuf_limits[j] = values[j];
+    }
+
+    return C_OK;
+}
+
 void initConfigValues() {
     for (standardConfig *config = configs; config->name != NULL; config++) {
         config->interface.init(config->data);
@@ -550,25 +606,7 @@ void loadServerConfigFromString(char *config) {
         } else if (!strcasecmp(argv[0],"client-output-buffer-limit") &&
                    argc == 5)
         {
-            int class = getClientTypeByName(argv[1]);
-            unsigned long long hard, soft;
-            int soft_seconds;
-
-            if (class == -1 || class == CLIENT_TYPE_MASTER) {
-                err = "Unrecognized client limit class: the user specified "
-                "an invalid one, or 'master' which has no buffer limits.";
-                goto loaderr;
-            }
-            hard = memtoull(argv[2],NULL);
-            soft = memtoull(argv[3],NULL);
-            soft_seconds = atoi(argv[4]);
-            if (soft_seconds < 0) {
-                err = "Negative number of seconds in soft limit is invalid";
-                goto loaderr;
-            }
-            server.client_obuf_limits[class].hard_limit_bytes = hard;
-            server.client_obuf_limits[class].soft_limit_bytes = soft;
-            server.client_obuf_limits[class].soft_limit_seconds = soft_seconds;
+            if (updateClientOutputBufferLimit(&argv[1], 4, &err) == C_ERR) goto loaderr;
         } else if (!strcasecmp(argv[0],"oom-score-adj-values") && argc == 1 + CONFIG_OOM_COUNT) {
             if (updateOOMScoreAdjValues(&argv[1], &err, 0) == C_ERR) goto loaderr;
         } else if (!strcasecmp(argv[0],"notify-keyspace-events") && argc == 2) {
@@ -760,7 +798,6 @@ void loadServerConfig(char *filename, char config_from_stdin, char *options) {
 void configSetCommand(client *c) {
     robj *o;
     long long ll;
-    int err;
     const char *errstr = NULL;
     serverAssertWithInfo(c,c->argv[2],sdsEncodedObject(c->argv[2]));
     serverAssertWithInfo(c,c->argv[3],sdsEncodedObject(c->argv[3]));
@@ -842,54 +879,14 @@ void configSetCommand(client *c) {
             return;
         }
     } config_set_special_field("client-output-buffer-limit") {
-        int vlen, j;
+        int vlen;
         sds *v = sdssplitlen(o->ptr,sdslen(o->ptr)," ",1,&vlen);
 
-        /* We need a multiple of 4: <class> <hard> <soft> <soft_seconds> */
-        if (vlen % 4) {
-            sdsfreesplitres(v,vlen);
+        if (updateClientOutputBufferLimit(v, vlen, &errstr) == C_ERR) {
+            sdsfreesplitres(v, vlen);
             goto badfmt;
         }
 
-        /* Sanity check of single arguments, so that we either refuse the
-         * whole configuration string or accept it all, even if a single
-         * error in a single client class is present. */
-        for (j = 0; j < vlen; j++) {
-            if ((j % 4) == 0) {
-                int class = getClientTypeByName(v[j]);
-                if (class == -1 || class == CLIENT_TYPE_MASTER)
-                    break;
-            } else if ((j % 4) == 3) {
-                char *endptr;
-                long l = strtoll(v[j],&endptr,10);
-                if (l < 0 || *endptr != '\0')
-                    break;
-            } else {
-                memtoull(v[j], &err);
-                if (err)
-                    break;
-            }
-        }
-        if (j < vlen) {
-            sdsfreesplitres(v,vlen);
-            goto badfmt;
-        }
-        
-        /* Finally set the new config */
-        for (j = 0; j < vlen; j += 4) {
-            int class;
-            unsigned long long hard, soft;
-            int soft_seconds;
-
-            class = getClientTypeByName(v[j]);
-            hard = memtoull(v[j+1],NULL);
-            soft = memtoull(v[j+2],NULL);
-            soft_seconds = strtoll(v[j+3],NULL,10);
-
-            server.client_obuf_limits[class].hard_limit_bytes = hard;
-            server.client_obuf_limits[class].soft_limit_bytes = soft;
-            server.client_obuf_limits[class].soft_limit_seconds = soft_seconds;
-        }
         sdsfreesplitres(v,vlen);
     } config_set_special_field("oom-score-adj-values") {
         int vlen;

--- a/src/config.h
+++ b/src/config.h
@@ -120,6 +120,7 @@
 /* Define rdb_fsync_range to sync_file_range() on Linux, otherwise we use
  * the plain fsync() call. */
 #if (defined(__linux__) && defined(SYNC_FILE_RANGE_WAIT_BEFORE))
+#define HAVE_SYNC_FILE_RANGE 1
 #define rdb_fsync_range(fd,off,size) sync_file_range(fd,off,size,SYNC_FILE_RANGE_WAIT_BEFORE|SYNC_FILE_RANGE_WRITE)
 #else
 #define rdb_fsync_range(fd,off,size) fsync(fd)

--- a/src/server.h
+++ b/src/server.h
@@ -151,7 +151,7 @@ typedef long long ustime_t; /* microsecond time type. */
 #define PROTO_MBULK_BIG_ARG     (1024*32)
 #define PROTO_RESIZE_THRESHOLD  (1024*32) /* Threshold for determining whether to resize query buffer */
 #define LONG_STR_SIZE      21          /* Bytes needed for long -> str + '\0' */
-#define REDIS_AUTOSYNC_BYTES (1024*1024*32) /* fdatasync every 32MB */
+#define REDIS_AUTOSYNC_BYTES (1024*1024*4) /* Sync file every 4MB. */
 
 #define LIMIT_PENDING_QUERYBUF (4*1024*1024) /* 4mb */
 

--- a/tests/integration/redis-benchmark.tcl
+++ b/tests/integration/redis-benchmark.tcl
@@ -13,7 +13,7 @@ start_server {tags {"benchmark network external:skip"}} {
         test {benchmark: set,get} {
             r config resetstat
             r flushall
-            set cmd [redisbenchmark $master_host $master_port "-c 5 -n 10 -e -t set,get"]
+            set cmd [redisbenchmark $master_host $master_port "-c 5 -n 10 -t set,get"]
             if {[catch { exec {*}$cmd } error]} {
                 set first_line [lindex [split $error "\n"] 0]
                 puts [colorstr red "redis-benchmark non zero code. first line: $first_line"]
@@ -27,7 +27,7 @@ start_server {tags {"benchmark network external:skip"}} {
 
         test {benchmark: full test suite} {
             r config resetstat
-            set cmd [redisbenchmark $master_host $master_port "-c 10 -n 100 -e"]
+            set cmd [redisbenchmark $master_host $master_port "-c 10 -n 100"]
             if {[catch { exec {*}$cmd } error]} {
                 set first_line [lindex [split $error "\n"] 0]
                 puts [colorstr red "redis-benchmark non zero code. first line: $first_line"]
@@ -57,7 +57,7 @@ start_server {tags {"benchmark network external:skip"}} {
         test {benchmark: multi-thread set,get} {
             r config resetstat
             r flushall
-            set cmd [redisbenchmark $master_host $master_port "--threads 10 -c 5 -n 10 -e -t set,get"]
+            set cmd [redisbenchmark $master_host $master_port "--threads 10 -c 5 -n 10 -t set,get"]
             if {[catch { exec {*}$cmd } error]} {
                 set first_line [lindex [split $error "\n"] 0]
                 puts [colorstr red "redis-benchmark non zero code. first line: $first_line"]
@@ -75,7 +75,7 @@ start_server {tags {"benchmark network external:skip"}} {
         test {benchmark: pipelined full set,get} {
             r config resetstat
             r flushall
-            set cmd [redisbenchmark $master_host $master_port "-P 5 -c 10 -n 10010 -e -t set,get"]
+            set cmd [redisbenchmark $master_host $master_port "-P 5 -c 10 -n 10010 -t set,get"]
             if {[catch { exec {*}$cmd } error]} {
                 set first_line [lindex [split $error "\n"] 0]
                 puts [colorstr red "redis-benchmark non zero code. first line: $first_line"]
@@ -93,7 +93,7 @@ start_server {tags {"benchmark network external:skip"}} {
         test {benchmark: arbitrary command} {
             r config resetstat
             r flushall
-            set cmd [redisbenchmark $master_host $master_port "-c 5 -n 150 -e INCRBYFLOAT mykey 10.0"]
+            set cmd [redisbenchmark $master_host $master_port "-c 5 -n 150 INCRBYFLOAT mykey 10.0"]
             if {[catch { exec {*}$cmd } error]} {
                 set first_line [lindex [split $error "\n"] 0]
                 puts [colorstr red "redis-benchmark non zero code. first line: $first_line"]

--- a/tests/unit/memefficiency.tcl
+++ b/tests/unit/memefficiency.tcl
@@ -73,7 +73,7 @@ start_server {tags {"defrag external:skip"} overrides {appendonly yes auto-aof-r
                 }
 
                 # Wait for the active defrag to stop working.
-                wait_for_condition 150 100 {
+                wait_for_condition 2000 100 {
                     [s active_defrag_running] eq 0
                 } else {
                     after 120 ;# serverCron only updates the info once in 100ms


### PR DESCRIPTION
Now, in the cluster mode. By using command CLUSTER DELSLOTS slot [slot ...] and command CLUSTER ADDSLOTS slot [slot ...]
user can only assign or forget discrete slot for a cluster node instead of a slot range.

Foe example, if user want to assign 1--5000 slot to a cluster node, user has only 2 choices:
option 1: run command CLUSTER ADDSLOTS 1 2 3 .... 4999 5000
option 2: assign these slot by bash shell command
redis-cli -h 127.0.0.1 -p 6379 cluster addslots {0...5000}


I would like to add 2 new commands:

CLUSTER DELSLOTSRANGE startslot endslot [startslot endslot...]
CLUSTER ADDSLOTSRANGE startslot endslot [startslot endslot...]

Thus, if I would like to assign 1 -- 5000 slot to current cluster node, user only need to run command:

cluster addslotsrange 1 5000

