### PR TITLE
Aof rdb logs

### DIFF
--- a/src/aof.c
+++ b/src/aof.c
@@ -1807,7 +1807,7 @@ void aofUpdateCurrentSize(void) {
 
     latencyStartMonitor(latency);
     if (redis_stat(server.aof_filename,&sb) == -1) {
-        serverLog(LL_WARNING,"Unable to obtain the AOF (%s) file length. stat: %s",
+        serverLog(LL_WARNING,"Unable to obtain the AOF file (%s) length. stat: %s",
             server.aof_filename,
             strerror(errno));
     } else {

--- a/src/aof.c
+++ b/src/aof.c
@@ -709,10 +709,10 @@ int loadAppendOnlyFile(char *filename) {
     if (fp == NULL) {
         int en = errno;
         if (redis_stat(filename, &sb) == 0) {
-            serverLog(LL_WARNING,"Fatal error: can't open the append log file for reading: %s",strerror(en));
+            serverLog(LL_WARNING,"Fatal error: can't open the append log file %s for reading: %s", filename, strerror(en));
             return AOF_OPEN_ERR;
         } else {
-            serverLog(LL_WARNING,"The append log file doesn't exist: %s",strerror(errno));
+            serverLog(LL_WARNING,"The append log file %s doesn't exist: %s", filename, strerror(errno));
             return AOF_NOT_EXIST;
         }
     }
@@ -895,7 +895,8 @@ uxeof: /* Unexpected AOF end of file. */
             if (valid_up_to == -1) {
                 serverLog(LL_WARNING,"Last valid command offset is invalid");
             } else {
-                serverLog(LL_WARNING,"Error truncating the AOF file: %s",
+                serverLog(LL_WARNING,"Error truncating the AOF file %s: %s",
+                    filename,
                     strerror(errno));
             }
         } else {
@@ -1806,7 +1807,8 @@ void aofUpdateCurrentSize(void) {
 
     latencyStartMonitor(latency);
     if (redis_stat(server.aof_filename,&sb) == -1) {
-        serverLog(LL_WARNING,"Unable to obtain the AOF file length. stat: %s",
+        serverLog(LL_WARNING,"Unable to obtain the AOF (%s) file length. stat: %s",
+            filename,
             strerror(errno));
     } else {
         server.aof_current_size = sb.st_size;

--- a/src/aof.c
+++ b/src/aof.c
@@ -1808,7 +1808,7 @@ void aofUpdateCurrentSize(void) {
     latencyStartMonitor(latency);
     if (redis_stat(server.aof_filename,&sb) == -1) {
         serverLog(LL_WARNING,"Unable to obtain the AOF (%s) file length. stat: %s",
-            filename,
+            server.aof_filename,
             strerror(errno));
     } else {
         server.aof_current_size = sb.st_size;

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1404,7 +1404,7 @@ int rdbSave(char *filename, rdbSaveInfo *rsi) {
         return C_ERR;
     }
 
-    serverLog(LL_NOTICE,"DB %s saved on disk.", filename);
+    serverLog(LL_NOTICE,"DB file %s saved on disk.", filename);
     server.dirty = 0;
     server.lastsave = time(NULL);
     server.lastbgsave_status = C_OK;
@@ -1412,7 +1412,7 @@ int rdbSave(char *filename, rdbSaveInfo *rsi) {
     return C_OK;
 
 werr:
-    serverLog(LL_WARNING,"Write error saving DB %s on disk: %s", filename, strerror(errno));
+    serverLog(LL_WARNING,"Write error saving DB file %s on disk: %s", filename, strerror(errno));
     if (fp) fclose(fp);
     unlink(tmpfile);
     stopSaving(0);
@@ -1442,7 +1442,7 @@ int rdbSaveBackground(char *filename, rdbSaveInfo *rsi) {
         /* Parent */
         if (childpid == -1) {
             server.lastbgsave_status = C_ERR;
-            serverLog(LL_WARNING,"Can't save %s in background: fork: %s",
+            serverLog(LL_WARNING,"Can't save file %s in background: fork: %s",
                 filename,
                 strerror(errno));
             return C_ERR;
@@ -2902,11 +2902,11 @@ int rdbLoadRio(rio *rdb, int rdbflags, rdbSaveInfo *rsi) {
 
     if (empty_keys_skipped) {
         serverLog(LL_WARNING,
-            "Done loading RDB %s, keys loaded: %lld, keys expired: %lld, empty keys skipped: %lld.",
+            "Done loading RDB file %s, keys loaded: %lld, keys expired: %lld, empty keys skipped: %lld.",
                 server.rdb_filename, server.rdb_last_load_keys_loaded, server.rdb_last_load_keys_expired, empty_keys_skipped);
     } else {
         serverLog(LL_NOTICE,
-            "Done loading RDB %s, keys loaded: %lld, keys expired: %lld.",
+            "Done loading RDB file %s, keys loaded: %lld, keys expired: %lld.",
                 server.rdb_filename, server.rdb_last_load_keys_loaded, server.rdb_last_load_keys_expired);
     }
     return C_OK;

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1404,7 +1404,7 @@ int rdbSave(char *filename, rdbSaveInfo *rsi) {
         return C_ERR;
     }
 
-    serverLog(LL_NOTICE,"DB saved on disk");
+    serverLog(LL_NOTICE,"DB %s saved on disk.". filename);
     server.dirty = 0;
     server.lastsave = time(NULL);
     server.lastbgsave_status = C_OK;
@@ -1412,7 +1412,7 @@ int rdbSave(char *filename, rdbSaveInfo *rsi) {
     return C_OK;
 
 werr:
-    serverLog(LL_WARNING,"Write error saving DB on disk: %s", strerror(errno));
+    serverLog(LL_WARNING,"Write error saving DB %s on disk: %s", filename, strerror(errno));
     if (fp) fclose(fp);
     unlink(tmpfile);
     stopSaving(0);

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -2888,7 +2888,7 @@ int rdbLoadRio(rio *rdb, int rdbflags, rdbSaveInfo *rsi) {
         if (server.rdb_checksum && !server.skip_checksum_validation) {
             memrev64ifbe(&cksum);
             if (cksum == 0) {
-                serverLog(LL_WARNING,"RDB file was saved with checksum disabled: no check performed.");
+                serverLog(LL_WARNING,"RDB file %s was saved with checksum disabled: no check performed.", server.rdb_filename);
             } else if (cksum != expected) {
                 serverLog(LL_WARNING,"Wrong RDB checksum expected: (%llx) but "
                     "got (%llx). Aborting now.",
@@ -2902,12 +2902,12 @@ int rdbLoadRio(rio *rdb, int rdbflags, rdbSaveInfo *rsi) {
 
     if (empty_keys_skipped) {
         serverLog(LL_WARNING,
-            "Done loading RDB, keys loaded: %lld, keys expired: %lld, empty keys skipped: %lld.",
-                server.rdb_last_load_keys_loaded, server.rdb_last_load_keys_expired, empty_keys_skipped);
+            "Done loading RDB %s, keys loaded: %lld, keys expired: %lld, empty keys skipped: %lld.",
+                server.rdb_filename, server.rdb_last_load_keys_loaded, server.rdb_last_load_keys_expired, empty_keys_skipped);
     } else {
         serverLog(LL_NOTICE,
-            "Done loading RDB, keys loaded: %lld, keys expired: %lld.",
-                server.rdb_last_load_keys_loaded, server.rdb_last_load_keys_expired);
+            "Done loading RDB %s, keys loaded: %lld, keys expired: %lld.",
+                server.rdb_filename, server.rdb_last_load_keys_loaded, server.rdb_last_load_keys_expired);
     }
     return C_OK;
 

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1442,7 +1442,8 @@ int rdbSaveBackground(char *filename, rdbSaveInfo *rsi) {
         /* Parent */
         if (childpid == -1) {
             server.lastbgsave_status = C_ERR;
-            serverLog(LL_WARNING,"Can't save in background: fork: %s",
+            serverLog(LL_WARNING,"Can't save %s in background: fork: %s",
+                filename,
                 strerror(errno));
             return C_ERR;
         }

--- a/src/rdb.c
+++ b/src/rdb.c
@@ -1404,7 +1404,7 @@ int rdbSave(char *filename, rdbSaveInfo *rsi) {
         return C_ERR;
     }
 
-    serverLog(LL_NOTICE,"DB %s saved on disk.". filename);
+    serverLog(LL_NOTICE,"DB %s saved on disk.", filename);
     server.dirty = 0;
     server.lastsave = time(NULL);
     server.lastbgsave_status = C_OK;

--- a/src/server.c
+++ b/src/server.c
@@ -7581,7 +7581,7 @@ void loadDataFromDisk(void) {
             rdb_flags |= RDBFLAGS_FEED_REPL;
         }
         if (rdbLoad(server.rdb_filename,&rsi,rdb_flags) == C_OK) {
-            serverLog(LL_NOTICE,"DB loaded from disk %s: %.3f seconds",
+            serverLog(LL_NOTICE,"DB %s loaded from disk: %.3f seconds",
                 server.rdb_filename,
                 (float)(ustime()-start)/1000000);
 

--- a/src/server.c
+++ b/src/server.c
@@ -7581,7 +7581,7 @@ void loadDataFromDisk(void) {
             rdb_flags |= RDBFLAGS_FEED_REPL;
         }
         if (rdbLoad(server.rdb_filename,&rsi,rdb_flags) == C_OK) {
-            serverLog(LL_NOTICE,"DB %s loaded from disk: %.3f seconds",
+            serverLog(LL_NOTICE,"DB loaded from RDB file %s disk: %.3f seconds",
                 server.rdb_filename,
                 (float)(ustime()-start)/1000000);
 
@@ -7626,7 +7626,7 @@ void loadDataFromDisk(void) {
                 }
             }
         } else if (errno != ENOENT) {
-            serverLog(LL_WARNING,"Fatal error loading the DB %s: %s. Exiting.", server.rdb_filename, strerror(errno));
+            serverLog(LL_WARNING,"Fatal error loading the DB file %s: %s. Exiting.", server.rdb_filename, strerror(errno));
             exit(1);
         }
 

--- a/src/server.c
+++ b/src/server.c
@@ -7569,7 +7569,7 @@ void loadDataFromDisk(void) {
         if (ret == AOF_FAILED || ret == AOF_OPEN_ERR)
             exit(1);
         if (ret == AOF_OK)
-            serverLog(LL_NOTICE,"DB loaded from append only file: %.3f seconds",(float)(ustime()-start)/1000000);
+            serverLog(LL_NOTICE,"DB loaded from append only file %s: %.3f seconds",server.aof_filename, (float)(ustime()-start)/1000000);
     } else {
         rdbSaveInfo rsi = RDB_SAVE_INFO_INIT;
         errno = 0; /* Prevent a stale value from affecting error checking */
@@ -7581,7 +7581,8 @@ void loadDataFromDisk(void) {
             rdb_flags |= RDBFLAGS_FEED_REPL;
         }
         if (rdbLoad(server.rdb_filename,&rsi,rdb_flags) == C_OK) {
-            serverLog(LL_NOTICE,"DB loaded from disk: %.3f seconds",
+            serverLog(LL_NOTICE,"DB loaded from disk %s: %.3f seconds",
+                server.rdb_filename,
                 (float)(ustime()-start)/1000000);
 
             /* Restore the replication ID / offset from the RDB file. */
@@ -7625,7 +7626,7 @@ void loadDataFromDisk(void) {
                 }
             }
         } else if (errno != ENOENT) {
-            serverLog(LL_WARNING,"Fatal error loading the DB: %s. Exiting.",strerror(errno));
+            serverLog(LL_WARNING,"Fatal error loading the DB %s: %s. Exiting.", server.rdb_filename, strerror(errno));
             exit(1);
         }
 
@@ -8047,8 +8048,9 @@ int main(int argc, char **argv) {
             server.aof_fd = open(server.aof_filename,
                                  O_WRONLY|O_APPEND|O_CREAT,0644);
             if (server.aof_fd == -1) {
-                serverLog(LL_WARNING, "Can't open the append-only file: %s",
-                          strerror(errno));
+                serverLog(LL_WARNING, "Can't open the append-only file %s: %s",
+                    server.aof_filename,
+                    strerror(errno));
                 exit(1);
             }
         }


### PR DESCRIPTION
This PR adds the filenames of the rdb and aof files to the logs in the following cases:

1) If no aof file the disk, and config file has appendonly yes
![image](https://user-images.githubusercontent.com/51993843/140397583-e858843e-5436-4bdb-b8d6-d48170cf7482.png)

2) When redis server startup, and loading data from rdb file
![image](https://user-images.githubusercontent.com/51993843/140397668-bc5d1d08-bece-41d3-a8fa-310cd7fd4266.png)

3) When redis server startup, and loading data from aof file
![image](https://user-images.githubusercontent.com/51993843/140398093-7209b79f-bd0d-46d9-be67-f9b3c41a7341.png)
