### PR TITLE
Provide better error message for Config Set

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -771,7 +771,7 @@ void configSetCommand(client *c) {
                 /* Apply function not stored, store it */
                 if (!exists) {
                     apply_fns[j] = set_configs[i]->interface.apply;
-                    config_map_fns[j] = i
+                    config_map_fns[j] = i;
                 }
                     
             }

--- a/src/config.c
+++ b/src/config.c
@@ -747,13 +747,10 @@ void configSetCommand(client *c) {
     for (i = 0; i < config_count; i++)
         old_values[i] = set_configs[i]->interface.get(set_configs[i]->data);
 
-    serverLog(LL_WARNING, "Before for loop Current error message is. %s", errstr);
-
     /* Set all new values (don't apply yet) */
     for (i = 0; i < config_count; i++) {
         int res = performInterfaceSet(set_configs[i], new_values[i], &errstr);
-        serverLog(LL_WARNING, "Current config number is. %d", i);
-        serverLog(LL_WARNING, "Current error message is %s", errstr);
+        
         if (!res) {
             err_arg_name = set_configs[i]->name;
             restoreBackupConfig(set_configs, old_values, i+1, NULL);
@@ -776,13 +773,17 @@ void configSetCommand(client *c) {
         }
     }
 
-    serverLog(LL_WARNING, "After for loop Current error message is %s", errstr);
+    for (i = 0; i < config_count; i++) {
+        if (apply_fns[i] == NULL) {
+            err_arg_name = set_configs[i]->name;
+            break;
+        }     
+    }
 
     /* Apply all configs after being set */
     for (i = 0; i < config_count && apply_fns[i] != NULL; i++) {
-        if (!apply_fns[i](&errstr)) {
-            serverLog(LL_WARNING, "Failed applying new %s configuration, restoring previous settings.", set_configs[i]->name);
-            //err_arg_name = set_configs[i]->name;
+        if(!apply_fns[i](&errstr)) {        
+            serverLog(LL_WARNING, "Failed applying new %s configuration, restoring previous settings.", set_configs[i]->name);            
             restoreBackupConfig(set_configs, old_values, config_count, apply_fns);
             goto err;
         }

--- a/src/config.c
+++ b/src/config.c
@@ -683,6 +683,7 @@ void configSetCommand(client *c) {
     apply_fn *apply_fns; /* TODO: make this a set for better performance */
     int config_count, i, j;
     int invalid_args = 0;
+    int *config_map_fns;
 
     /* Make sure we have an even number of arguments: conf-val pairs */
     if (c->argc & 1) {
@@ -695,6 +696,7 @@ void configSetCommand(client *c) {
     new_values = zmalloc(sizeof(sds*)*config_count);
     old_values = zcalloc(sizeof(sds*)*config_count);
     apply_fns = zcalloc(sizeof(apply_fn)*config_count);
+    config_map_fns = zmalloc(sizeof(int)*config_count);
 
     /* Find all relevant configs */
     for (i = 0; i < config_count; i++) {
@@ -767,24 +769,21 @@ void configSetCommand(client *c) {
                     }
                 }
                 /* Apply function not stored, store it */
-                if (!exists)
+                if (!exists) {
                     apply_fns[j] = set_configs[i]->interface.apply;
+                    config_map_fns[j] = i
+                }
+                    
             }
         }
-    }
-
-    for (i = 0; i < config_count; i++) {
-        if (apply_fns[i] == NULL) {
-            err_arg_name = set_configs[i]->name;
-            break;
-        }     
     }
 
     /* Apply all configs after being set */
     for (i = 0; i < config_count && apply_fns[i] != NULL; i++) {
         if(!apply_fns[i](&errstr)) {        
-            serverLog(LL_WARNING, "Failed applying new %s configuration, restoring previous settings.", set_configs[i]->name);            
+            serverLog(LL_WARNING, "Failed applying new %s configuration, restoring previous settings.", set_configs[config_map_fns[i]]->name);            
             restoreBackupConfig(set_configs, old_values, config_count, apply_fns);
+            err_arg_name = set_configs[config_map_fns[i]]->name;
             goto err;
         }
     }
@@ -806,6 +805,7 @@ end:
         sdsfree(old_values[i]);
     zfree(old_values);
     zfree(apply_fns);
+    zfree(config_map_fns);
 }
 
 /*-----------------------------------------------------------------------------

--- a/src/config.c
+++ b/src/config.c
@@ -673,6 +673,10 @@ static void restoreBackupConfig(standardConfig **set_configs, sds *old_values, i
 
 void configSetCommand(client *c) {
     const char *errstr = NULL;
+    const char *invalid_arg_name = NULL;
+    const char *err_arg_name = NULL;
+
+
     standardConfig **set_configs; /* TODO: make this a dict for better performance */
     sds *new_values;
     sds *old_values = NULL;
@@ -709,6 +713,7 @@ void configSetCommand(client *c) {
                     if (config->flags & IMMUTABLE_CONFIG) {
                         /* Note: we don't abort the loop since we still want to handle redacting sensitive configs (above) */
                         errstr = "can't set immutable config";
+                        err_arg_name = c->argv[2+i*2]->ptr;
                         invalid_args = 1;
                     }
 
@@ -717,6 +722,7 @@ void configSetCommand(client *c) {
                         if (set_configs[j] == config) {
                             /* Note: we don't abort the loop since we still want to handle redacting sensitive configs (above) */
                             errstr = "duplicate parameter";
+                            err_arg_name = c->argv[2+i*2]->ptr;
                             invalid_args = 1;
                             break;
                         }
@@ -730,7 +736,7 @@ void configSetCommand(client *c) {
         /* Fail if we couldn't find this config */
         /* Note: we don't abort the loop since we still want to handle redacting sensitive configs (above) */
         if (!invalid_args && !set_configs[i]) {
-            errstr = "unrecognized parameter";
+            invalid_arg_name = c->argv[2+i*2]->ptr;
             invalid_args = 1;
         }
     }
@@ -741,10 +747,15 @@ void configSetCommand(client *c) {
     for (i = 0; i < config_count; i++)
         old_values[i] = set_configs[i]->interface.get(set_configs[i]->data);
 
+    serverLog(LL_WARNING, "Before for loop Current error message is. %s", errstr);
+
     /* Set all new values (don't apply yet) */
     for (i = 0; i < config_count; i++) {
         int res = performInterfaceSet(set_configs[i], new_values[i], &errstr);
+        serverLog(LL_WARNING, "Current config number is. %d", i);
+        serverLog(LL_WARNING, "Current error message is %s", errstr);
         if (!res) {
+            err_arg_name = set_configs[i]->name;
             restoreBackupConfig(set_configs, old_values, i+1, NULL);
             goto err;
         } else if (res == 1) {
@@ -765,10 +776,13 @@ void configSetCommand(client *c) {
         }
     }
 
+    serverLog(LL_WARNING, "After for loop Current error message is %s", errstr);
+
     /* Apply all configs after being set */
     for (i = 0; i < config_count && apply_fns[i] != NULL; i++) {
         if (!apply_fns[i](&errstr)) {
             serverLog(LL_WARNING, "Failed applying new %s configuration, restoring previous settings.", set_configs[i]->name);
+            //err_arg_name = set_configs[i]->name;
             restoreBackupConfig(set_configs, old_values, config_count, apply_fns);
             goto err;
         }
@@ -777,8 +791,10 @@ void configSetCommand(client *c) {
     goto end;
 
 err:
-    if (errstr) {
-        addReplyErrorFormat(c,"Config set failed - %s", errstr);
+    if (invalid_arg_name) {
+        addReplyErrorFormat(c,"Unknown option or number of arguments for CONFIG SET - '%s'", invalid_arg_name);
+    } else if (errstr) {
+        addReplyErrorFormat(c,"argument '%s' for CONFIG SET failed - %s", err_arg_name, errstr);
     } else {
         addReplyError(c,"Invalid arguments");
     }

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -322,7 +322,7 @@ start_server {tags {"introspection"}} {
         # Set some value to maxmemory
         assert_equal [r config set maxmemory 10000002] "OK"
         # Set another value to maxmeory together with another invalid config
-        assert_error "ERR Config set failed - percentage argument must be less or equal to 100" {
+        assert_error "ERR argument 'maxmemory-clients' for CONFIG SET failed - percentage argument must be less or equal to 100" {
             r config set maxmemory 10000001 maxmemory-clients 200% client-query-buffer-limit invalid
         }
         # Validate we rolled back to original values
@@ -375,7 +375,8 @@ start_server {tags {"introspection"}} {
 
         # Try to listen on the used port, pass some more configs to make sure the
         # returned failure message is for the first bad config and everything is rolled back.
-        assert_error "ERR Config set failed - Unable to listen on this port*" {
+        puts $some_configs
+        assert_error "ERR argument port for Config SET failed - Unable to listen on this port*" {
             eval "r config set $some_configs"
         }
 

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -375,7 +375,6 @@ start_server {tags {"introspection"}} {
 
         # Try to listen on the used port, pass some more configs to make sure the
         # returned failure message is for the first bad config and everything is rolled back.
-        puts $some_configs
         assert_error "ERR argument 'port' for CONFIG SET failed - Unable to listen on this port*" {
             eval "r config set $some_configs"
         }

--- a/tests/unit/introspection.tcl
+++ b/tests/unit/introspection.tcl
@@ -376,7 +376,7 @@ start_server {tags {"introspection"}} {
         # Try to listen on the used port, pass some more configs to make sure the
         # returned failure message is for the first bad config and everything is rolled back.
         puts $some_configs
-        assert_error "ERR argument port for Config SET failed - Unable to listen on this port*" {
+        assert_error "ERR argument 'port' for CONFIG SET failed - Unable to listen on this port*" {
             eval "r config set $some_configs"
         }
 


### PR DESCRIPTION
Now, when clients run the sentinel set command, if the parameter or the value are not proper, sentinel could provide good error message as following:

![image](https://user-images.githubusercontent.com/51993843/145069863-ce1f6d21-da19-49ce-badf-bdc69c5dda4a.png)

However, in the redis server client-cli, when clients enter the incorrect parameter or value, the error messages are not clear as following:

