### PR TITLE
Getex extra options to avoid duplicate options

### DIFF
--- a/src/t_string.c
+++ b/src/t_string.c
@@ -228,14 +228,14 @@ int parseExtendedStringArgumentsOrReply(client *c, int *flags, int *unit, robj *
         } else if (!strcasecmp(opt,"PERSIST") && (command_type == COMMAND_GET) &&
                !(*flags & OBJ_EX) && !(*flags & OBJ_EXAT) &&
                !(*flags & OBJ_PX) && !(*flags & OBJ_PXAT) &&
-               !(*flags & OBJ_KEEPTTL))
+               !(*flags & OBJ_KEEPTTL) && !(*flags & OBJ_PERSIST))
         {
             *flags |= OBJ_PERSIST;
         } else if ((opt[0] == 'e' || opt[0] == 'E') &&
                    (opt[1] == 'x' || opt[1] == 'X') && opt[2] == '\0' &&
                    !(*flags & OBJ_KEEPTTL) && !(*flags & OBJ_PERSIST) &&
                    !(*flags & OBJ_EXAT) && !(*flags & OBJ_PX) &&
-                   !(*flags & OBJ_PXAT) && next)
+                   !(*flags & OBJ_PXAT) && next && !(*flags & OBJ_EX))
         {
             *flags |= OBJ_EX;
             *expire = next;
@@ -244,7 +244,7 @@ int parseExtendedStringArgumentsOrReply(client *c, int *flags, int *unit, robj *
                    (opt[1] == 'x' || opt[1] == 'X') && opt[2] == '\0' &&
                    !(*flags & OBJ_KEEPTTL) && !(*flags & OBJ_PERSIST) &&
                    !(*flags & OBJ_EX) && !(*flags & OBJ_EXAT) &&
-                   !(*flags & OBJ_PXAT) && next)
+                   !(*flags & OBJ_PXAT) && next && !(*flags & OBJ_PX))
         {
             *flags |= OBJ_PX;
             *unit = UNIT_MILLISECONDS;
@@ -256,7 +256,7 @@ int parseExtendedStringArgumentsOrReply(client *c, int *flags, int *unit, robj *
                    (opt[3] == 't' || opt[3] == 'T') && opt[4] == '\0' &&
                    !(*flags & OBJ_KEEPTTL) && !(*flags & OBJ_PERSIST) &&
                    !(*flags & OBJ_EX) && !(*flags & OBJ_PX) &&
-                   !(*flags & OBJ_PXAT) && next)
+                   !(*flags & OBJ_PXAT) && next && !(*flags & OBJ_EXAT))
         {
             *flags |= OBJ_EXAT;
             *expire = next;
@@ -267,7 +267,7 @@ int parseExtendedStringArgumentsOrReply(client *c, int *flags, int *unit, robj *
                    (opt[3] == 't' || opt[3] == 'T') && opt[4] == '\0' &&
                    !(*flags & OBJ_KEEPTTL) && !(*flags & OBJ_PERSIST) &&
                    !(*flags & OBJ_EX) && !(*flags & OBJ_EXAT) &&
-                   !(*flags & OBJ_PX) && next)
+                   !(*flags & OBJ_PX) && next && !(*flags & OBJ_PXAT))
         {
             *flags |= OBJ_PXAT;
             *unit = UNIT_MILLISECONDS;


### PR DESCRIPTION
This PR fixes the bug in redis related to getex.
Currently there is no check if duplicate options are added. For example
getex key ex 100 ex 400 will set the expiry to 400 and ignore ex 100
![image](https://user-images.githubusercontent.com/51993843/157745163-ad40a180-6620-46bb-b979-0bf6c4926769.png)

getex key ex x ex 400 will set the expiry to 400 and ignore the wrong argument x for ex
![image](https://user-images.githubusercontent.com/51993843/157745204-9e894d90-4e03-4522-901e-d8aef23ac8b7.png)

After the change we get the following result which is the default error being used in redis
![image](https://user-images.githubusercontent.com/51993843/157745245-c2f2a2ee-76f4-4a55-824c-270b70ca295f.png)



